### PR TITLE
Embed test files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,27 @@
+name: Test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Go cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - name: Configure Agent
+        run: go run mage.go ConfigureAgent
+      - name: Build
+        run: mage Build
+      - name: Test
+        run: mage Test

--- a/mage.go
+++ b/mage.go
@@ -1,0 +1,15 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"os"
+
+	"github.com/magefile/mage/mage"
+)
+
+// This file allows someone to run mage commands without mage installed
+// by running `go run mage.go TARGET`.
+// See https://magefile.org/zeroinstall/
+func main() { os.Exit(mage.Main()) }

--- a/magefile.go
+++ b/magefile.go
@@ -4,10 +4,16 @@
 package main
 
 import (
+	"get.porter.sh/magefiles/ci"
+	"github.com/carolynvs/magex/mgx"
 	"github.com/carolynvs/magex/shx"
 )
 
 var must = shx.CommandBuilder{StopOnError: true}
+
+func ConfigureAgent() {
+	mgx.Must(ci.ConfigureAgent())
+}
 
 func Build() {
 	must.RunV("go", "build", "./...")


### PR DESCRIPTION
Previously these files were directly in the repository, so we could get away with loading the files as needed. Now that it's used as a library, we have to use go:embed so that we can use the file contents from another repository.

I have also added a GitHub workflow to run the tests.