### PR TITLE
XBuildAll expects to publish a mixin

### DIFF
--- a/mixins/magefile.go
+++ b/mixins/magefile.go
@@ -35,6 +35,7 @@ func (m Magefile) Build() {
 // Cross-compile the mixin before a release
 func (m Magefile) XBuildAll() {
 	releases.XBuildAll(m.Pkg, m.MixinName, m.BinDir)
+	releases.PrepareMixinForPublish(m.MixinName)
 }
 
 // Run unit tests

--- a/releases/build.go
+++ b/releases/build.go
@@ -85,6 +85,4 @@ func XBuildAll(pkg string, name string, binDir string) {
 	// Copy most recent build into bin/dev so that subsequent build steps can easily find it, not used for publishing
 	os.RemoveAll(filepath.Join(binDir, "dev"))
 	shx.Copy(filepath.Join(binDir, info.Version), filepath.Join(binDir, "dev"), shx.CopyRecursive)
-
-	PrepareMixinForPublish(name)
 }

--- a/tools/install.go
+++ b/tools/install.go
@@ -3,7 +3,6 @@ package tools
 import (
 	"fmt"
 	"log"
-	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/carolynvs/magex/pkg"
 	"github.com/carolynvs/magex/pkg/archive"
 	"github.com/carolynvs/magex/pkg/downloads"
-	"github.com/carolynvs/magex/pkg/gopath"
 )
 
 const (
@@ -86,7 +84,7 @@ func EnsureKind() {
 
 // Install kind at the specified version
 func EnsureKindAt(version string) {
-	if ok, _ := pkg.IsCommandAvailable(filepath.Join(gopath.GetGopathBin(), "kind"), ""); ok {
+	if ok, _ := pkg.IsCommandAvailable("kind", ""); ok {
 		return
 	}
 

--- a/tools/install.go
+++ b/tools/install.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/carolynvs/magex/pkg"
 	"github.com/carolynvs/magex/pkg/archive"
 	"github.com/carolynvs/magex/pkg/downloads"
+	"github.com/carolynvs/magex/pkg/gopath"
 )
 
 const (
@@ -84,7 +86,7 @@ func EnsureKind() {
 
 // Install kind at the specified version
 func EnsureKindAt(version string) {
-	if ok, _ := pkg.IsCommandAvailable("kind", ""); ok {
+	if ok, _ := pkg.IsCommandAvailable(filepath.Join(gopath.GetGopathBin(), "kind"), ""); ok {
 		return
 	}
 

--- a/tools/install_test.go
+++ b/tools/install_test.go
@@ -1,16 +1,19 @@
 package tools_test
 
 import (
+	"path/filepath"
+	"testing"
+
 	"get.porter.sh/magefiles/tools"
 	"github.com/carolynvs/magex/pkg"
+	"github.com/carolynvs/magex/pkg/gopath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestEnsureKind(t *testing.T) {
 	tools.EnsureKind()
-	found, err := pkg.IsCommandAvailable("kind", tools.DefaultKindVersion, "--version")
+	found, err := pkg.IsCommandAvailable(filepath.Join(gopath.GetGopathBin(), "kind"), tools.DefaultKindVersion, "--version")
 	require.NoError(t, err)
 	assert.True(t, found)
 }

--- a/tools/install_test.go
+++ b/tools/install_test.go
@@ -1,19 +1,20 @@
 package tools_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"get.porter.sh/magefiles/tools"
 	"github.com/carolynvs/magex/pkg"
 	"github.com/carolynvs/magex/pkg/gopath"
+	"github.com/carolynvs/magex/xplat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEnsureKind(t *testing.T) {
 	tools.EnsureKind()
-	found, err := pkg.IsCommandAvailable(filepath.Join(gopath.GetGopathBin(), "kind"), tools.DefaultKindVersion, "--version")
+	xplat.PrependPath(gopath.GetGopathBin())
+	found, err := pkg.IsCommandAvailable("kind", tools.DefaultKindVersion, "--version")
 	require.NoError(t, err)
 	assert.True(t, found)
 }


### PR DESCRIPTION
Fixes #4

Fixed another issue with `EnsureKind` and `kind` outside of $GOPATH/bin.  I can break that out to another issue if needed.

Signed-off-by: Brian DeGeeter <b.degeeter@f5.com>