### PR TITLE
Fix publish of checksum files

### DIFF
--- a/releases/testdata/mixins/v1.2.3/mymixin-darwin-amd64.sha256sum
+++ b/releases/testdata/mixins/v1.2.3/mymixin-darwin-amd64.sha256sum
@@ -1,0 +1,1 @@
+bad checksum file contents, should be overwritten


### PR DESCRIPTION
When the checksum files are already exist in the bin directory, duplicate paths were recorded, and included in the gh release.

This caused creating a release to fail.

```
exec: /usr/bin/gh gh release create -R github.com/getporter/kubernetes-plugins -t v0.2.0 --notes= v0.2.0 bin/plugins/kubernetes/v0.2.0/kubernetes-darwin-amd64 bin/plugins/kubernetes/v0.2.0/kubernetes-darwin-amd64.sha256sum bin/plugins/kubernetes/v0.2.0/kubernetes-linux-amd64 bin/plugins/kubernetes/v0.2.0/kubernetes-linux-amd64.sha256sum bin/plugins/kubernetes/v0.2.0/kubernetes-windows-amd64.exe bin/plugins/kubernetes/v0.2.0/kubernetes-windows-amd64.exe.sha256sum bin/plugins/kubernetes/v0.2.0/kubernetes-darwin-amd64.sha256sum bin/plugins/kubernetes/v0.2.0/kubernetes-darwin-amd64.sha256sum bin/plugins/kubernetes/v0.2.0/kubernetes-linux-amd64.sha256sum bin/plugins/kubernetes/v0.2.0/kubernetes-linux-amd64.sha256sum bin/plugins/kubernetes/v0.2.0/kubernetes-windows-amd64.exe.sha256sum bin/plugins/kubernetes/v0.2.0/kubernetes-windows-amd64.exe.sha256sum
HTTP 422: Validation Failed (https://uploads.github.com/repos/getporter/kubernetes-plugins/releases/64896892/assets?label=&name=kubernetes-windows-amd64.exe.sha256sum)
ReleaseAsset.name already exists
```
I have updated the logic to only get a list of unique files. I've also changed the release creation logic so that we always create the release and upload the assets separately. The error handling in the upload command seems to be better than in the release create command.
