### PR TITLE
Fix bad draft flag

### DIFF
--- a/releases/publish.go
+++ b/releases/publish.go
@@ -194,7 +194,7 @@ func AddFilesToRelease(repo string, tag string, dir string) {
 		}
 
 		// Create the GH release
-		must.RunV("gh", "release", "create", "-R", repo, tag, "--notes=", draft)
+		must.Command("gh", "release", "create", "-R", repo, tag, "--notes=", draft).CollapseArgs().RunV()
 	}
 
 	// Upload the release assets and overwrite existing assets


### PR DESCRIPTION
When we run the create release command, we may pass in an empty flag, which needs to be pruned by CollapseArgs. Otherwise the command will fail because it thinks we are  passing in a file to upload with the release (with a name of "").