### PR TITLE
Fix generatePackageFeed when porter isn't installed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push,pull_request]
 
+env:
+  MAGEFILE_VERBOSE: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/releases/publish.go
+++ b/releases/publish.go
@@ -143,7 +143,7 @@ func publishPackageFeed(pkgType string, name string) {
 	must.RunV("git", "clone", "--depth=1", remote, packagesRepo)
 	configureGitBotIn(packagesRepo)
 
-	generatePackageFeed(pkgType)
+	mgx.Must(generatePackageFeed(pkgType))
 
 	must.Command("git", "-c", "user.name='Porter Bot'", "-c", "user.email=bot@porter.sh", "commit", "--signoff", "-am", fmt.Sprintf("Add %s@%s to %s feed", name, info.Version, pkgType)).
 		In(packagesRepo).RunV()
@@ -167,7 +167,7 @@ func generatePackageFeed(pkgType string) error {
 		return err
 	}
 
-	return shx.RunE("porter", "mixins", "feed", "generate", "-d", filepath.Join("bin", pkgDir), "-f", feedFile, "-t", "build/atom-template.xml")
+	return shx.RunE("bin/porter", "mixins", "feed", "generate", "-d", filepath.Join("bin", pkgDir), "-f", feedFile, "-t", "build/atom-template.xml")
 }
 
 // Generate a mixin feed from any mixin versions in bin/mixins.

--- a/tools/install.go
+++ b/tools/install.go
@@ -93,7 +93,7 @@ func EnsureKind() {
 
 // Install kind at the specified version
 func EnsureKindAt(version string) {
-	if ok, _ := pkg.IsCommandAvailable("kind", ""); ok {
+	if ok, _ := pkg.IsCommandAvailable("kind", version); ok {
 		return
 	}
 

--- a/tools/install_test.go
+++ b/tools/install_test.go
@@ -1,6 +1,9 @@
 package tools_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"get.porter.sh/magefiles/tools"
@@ -12,9 +15,17 @@ import (
 )
 
 func TestEnsureKind(t *testing.T) {
-	tools.EnsureKind()
+	tmp, err := ioutil.TempDir("", "magefiles")
+	require.NoError(t, err, "Error creating temp directory")
+	defer os.RemoveAll(tmp)
+
+	os.Setenv("GOPATH", tmp)
+	tools.EnsureKindAt(tools.DefaultKindVersion)
 	xplat.PrependPath(gopath.GetGopathBin())
+
+	require.FileExists(t, filepath.Join(tmp, "bin", "kind"+xplat.FileExt()))
+
 	found, err := pkg.IsCommandAvailable("kind", tools.DefaultKindVersion, "--version")
-	require.NoError(t, err)
-	assert.True(t, found)
+	require.NoError(t, err, "IsCommandAvailable failed")
+	assert.True(t, found, "kind was not available from its location in GOPATH/bin. PATH=%s", os.Getenv("PATH"))
 }


### PR DESCRIPTION
1. We weren't checking for an error when calling generatePackageFeed so it appeared successful when it was not.
2. Call bin/porter instead of Porter so that when a dev runs the target locally, it will fail if they forgot to call EnsurePorter to install porter into the bin. It's hard to troubleshoot when it fails only in CI because your dev machine has porter on the PATH.

I've also fixed a test that started to fail since the last time it was ran. TestEnsureKind assumed that kind wasn't already installed.
