### PR TITLE
Only download porter runtime when porter changes

### DIFF
--- a/porter/porter_test.go
+++ b/porter/porter_test.go
@@ -41,9 +41,8 @@ func TestEnsurePorterAt(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmp, err := ioutil.TempDir("", "magefiles")
+			tmp, err := os.MkdirTemp("", "magefiles")
 			require.NoError(t, err)
-			defer os.RemoveAll(tmp)
 
 			UsePorterHome(tmp)
 			EnsurePorterAt(tc.wantVersion)
@@ -55,4 +54,38 @@ func TestEnsurePorterAt(t *testing.T) {
 			assert.True(t, ok, "could not resolve the desired porter version")
 		})
 	}
+
+	// when the runtime binary already exists, leave it
+	t.Run("runtime binary only downloaded when client is stale", func(t *testing.T) {
+		tmp, err := os.MkdirTemp("", "magefiles")
+		require.NoError(t, err)
+
+		UsePorterHome(tmp)
+		EnsurePorter()
+
+		porterPath := filepath.Join(tmp, "porter"+xplat.FileExt())
+		runtimePath := filepath.Join(tmp, "runtimes", "porter-runtime")
+		origPorterStat, err := os.Stat(porterPath)
+		require.NoError(t, err, "failed to stat the porter binary")
+		origRuntimeStat, err := os.Stat(runtimePath)
+		require.NoError(t, err, "failed to stat the porter-runtime binary")
+
+		// Nothing should be downloaded
+		EnsurePorterAt(DefaultPorterVersion)
+		newPorterStat, err := os.Stat(porterPath)
+		require.NoError(t, err, "failed to stat the porter binary")
+		require.Equal(t, origPorterStat.ModTime(), newPorterStat.ModTime(), "expected the porter binary to not be re-downloaded")
+		newRuntimeStat, err := os.Stat(runtimePath)
+		require.NoError(t, err, "failed to stat the porter-runtime binary")
+		require.Equal(t, origRuntimeStat.ModTime(), newRuntimeStat.ModTime(), "expected the porter-runtime binary to not be re-downloaded")
+
+		// Both should be re-downloaded
+		EnsurePorterAt("v1.0.0-rc.1")
+		newPorterStat, err = os.Stat(porterPath)
+		require.NoError(t, err, "failed to stat the porter binary")
+		require.Less(t, origPorterStat.ModTime(), newPorterStat.ModTime(), "expected the porter binary to be re-downloaded")
+		newRuntimeStat, err = os.Stat(runtimePath)
+		require.NoError(t, err, "failed to stat the porter-runtime binary")
+		require.Less(t, origRuntimeStat.ModTime(), newRuntimeStat.ModTime(), "expected the porter-runtime binary to be re-downloaded")
+	})
 }

--- a/porter/porter_test.go
+++ b/porter/porter_test.go
@@ -41,8 +41,7 @@ func TestEnsurePorterAt(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmp, err := os.MkdirTemp("", "magefiles")
-			require.NoError(t, err)
+			tmp := t.TempDir()
 
 			UsePorterHome(tmp)
 			EnsurePorterAt(tc.wantVersion)
@@ -57,8 +56,7 @@ func TestEnsurePorterAt(t *testing.T) {
 
 	// when the runtime binary already exists, leave it
 	t.Run("runtime binary only downloaded when client is stale", func(t *testing.T) {
-		tmp, err := os.MkdirTemp("", "magefiles")
-		require.NoError(t, err)
+		tmp := t.TempDir()
 
 		UsePorterHome(tmp)
 		EnsurePorter()


### PR DESCRIPTION
This fixes the EnsurePorter helper so that the porter-runtime binary isn't constantly re-downloaded on a mac/win dev machine. I was trying to download only when the version was out of date but that can't be reliably checked on all platforms since the runtime binary is always linux. So the version check was failing every time (and causing a download).

I've updated the EnsurePorter logic so that we download the runtime binary when:
* It's missing
* We downloaded the client

This way repeated builds won't re-download anything, but if the change the desired client version that will force the runtime to download too.