### PR TITLE
Add SetupDCO target

### DIFF
--- a/git/dco.go
+++ b/git/dco.go
@@ -1,0 +1,55 @@
+package git
+
+import (
+	"bufio"
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/carolynvs/magex/xplat"
+)
+
+//go:embed dco/prepare-commit-msg
+var prepareCommitMsg string
+
+// SetupDCO configures your git repository to automatically sign your commits
+// to comply with our DCO
+func SetupDCO() error {
+	gotShell := xplat.DetectShell()
+	if gotShell == "powershell" || gotShell == "cmd" {
+		return fmt.Errorf("SetupDCO must be run from a shell that supports bash but %s was detected\n", gotShell)
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("unable to determine the current working directory: %w", err)
+	}
+	repoRoot, err := FindRepositoryRoot(pwd)
+	if err != nil {
+		return err
+	}
+	hooksDir := filepath.Join(repoRoot, ".git/hooks/")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		return fmt.Errorf("error ensuring that %s exists: %w", hooksDir, err)
+	}
+	hookPath := filepath.Join(hooksDir, "prepare-commit-msg")
+
+	// Ask first before overwriting an existing hook
+	_, err = os.Stat(hookPath)
+	if err == nil {
+		fmt.Printf("The DCO hook is already installed. Overwrite? [yN]: ")
+		reader := bufio.NewReader(os.Stdin)
+		response, _ := reader.ReadString('\n')
+		if !strings.HasPrefix(strings.ToLower(response), "y") {
+			fmt.Println("The DCO hook was not installed")
+			return nil
+		}
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("unable to read %s: %w", hookPath, err)
+	}
+
+	fmt.Println("Installing DCO git commit hook")
+	return os.WriteFile(hookPath, []byte(prepareCommitMsg), 0755)
+}

--- a/git/dco/prepare-commit-msg
+++ b/git/dco/prepare-commit-msg
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# A git commit hook that will automatically append a DCO signoff to the bottom
+# of any commit message that doesn't have one. This append happens after the git
+# default message is generated, but before the user is dropped into the commit
+# message editor.
+
+COMMIT_MESSAGE_FILE="$1"
+AUTHOR=$(git var GIT_AUTHOR_IDENT)
+SIGNOFF=$(echo $AUTHOR | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+
+# Check for DCO signoff message. If one doesn't exist, append one and then warn
+# the user that you did so.
+if ! $(grep -qs "^$SIGNOFF" "$COMMIT_MESSAGE_FILE") ; then
+  echo -e "\n$SIGNOFF" >> "$COMMIT_MESSAGE_FILE"
+  echo -e "Appended the following signoff to the end of the commit message:\n  $SIGNOFF\n"
+fi

--- a/git/dco_test.go
+++ b/git/dco_test.go
@@ -1,0 +1,41 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupDCO(t *testing.T) {
+	t.Run("git exists", func(t *testing.T) {
+		tmp := t.TempDir()
+		testDir := filepath.Join(tmp, "a/b")
+		require.NoError(t, os.MkdirAll(testDir, 0755))
+		gitDir := filepath.Join(tmp, ".git")
+		require.NoError(t, os.Mkdir(gitDir, 0755))
+
+		require.NoError(t, os.Chdir(testDir))
+		require.NoError(t, SetupDCO())
+
+		// test that the hook was created
+		hookPath := filepath.Join(gitDir, "hooks/prepare-commit-msg")
+		require.FileExists(t, hookPath)
+		hookContents, err := os.ReadFile(hookPath)
+		require.NoErrorf(t, err, "error reading %s", hookPath)
+		assert.Equal(t, string(hookContents), prepareCommitMsg, "unexpected hook file contents found")
+	})
+
+	t.Run("git exists", func(t *testing.T) {
+		tmp := t.TempDir()
+		testPath := filepath.Join(tmp, "a/b")
+		require.NoError(t, os.MkdirAll(testPath, 0755))
+		// there is not .git directory
+
+		require.NoError(t, os.Chdir(testPath))
+		err := SetupDCO()
+		require.ErrorContains(t, err, "could not find the repository root")
+	})
+}

--- a/git/fs.go
+++ b/git/fs.go
@@ -1,0 +1,41 @@
+package git
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// FindRepositoryRoot looks up the tree from the specified absolute path
+// to determine the path of the parent git repository
+func FindRepositoryRoot(dir string) (string, error) {
+	for {
+		if dirHasChild(dir, ".git") {
+			return dir, nil
+		}
+
+		dir = filepath.Dir(dir)
+		if dir == "." || dir == "" || dir == filepath.Dir(dir) {
+			break
+		}
+	}
+
+	return "", fmt.Errorf("could not find the repository root")
+}
+
+// dirHasChild determines if the specified absolute path to a directory contains
+// a child with the desired name.
+func dirHasChild(dir string, childName string) bool {
+	children, err := os.ReadDir(dir)
+	if err != nil {
+		log.Println(err)
+		return false
+	}
+	for _, child := range children {
+		if child.Name() == childName {
+			return true
+		}
+	}
+	return false
+}

--- a/releases/publish.go
+++ b/releases/publish.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -70,7 +69,7 @@ func configureGitBotIn(dir string) {
 	contents := `#!/bin/sh
 exec echo "$GITHUB_TOKEN"
 `
-	mgx.Must(ioutil.WriteFile(askpass, []byte(contents), 0770))
+	mgx.Must(os.WriteFile(askpass, []byte(contents), 0770))
 
 	pwd, _ := os.Getwd()
 	script := filepath.Join(pwd, askpass)
@@ -227,7 +226,7 @@ func releaseExists(repo string, version string) bool {
 }
 
 func listFiles(dir string) []string {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		mgx.Must(fmt.Errorf("error listing files in %s: %w", dir, err))
 	}


### PR DESCRIPTION
Add a target that sets up the prepare-commit-msg hook for the current repository so that every commit is automatically signed.