### PR TITLE
Stop if a mixin build fails

### DIFF
--- a/mixins/magefile.go
+++ b/mixins/magefile.go
@@ -35,7 +35,7 @@ func (m Magefile) ConfigureAgent() {
 // Build the mixin
 func (m Magefile) Build() {
 	must.RunV("go", "mod", "tidy")
-	releases.BuildAll(m.Pkg, m.MixinName, m.BinDir)
+	mgx.Must(releases.BuildAll(m.Pkg, m.MixinName, m.BinDir))
 }
 
 // XBuildAll cross-compiles the mixin before a release


### PR DESCRIPTION
Check if build failed and halt immediately. his ensures that if a user runs `mage build test` that when build fails, test is not run.