### PR TITLE
Upload assets when we create the release

### DIFF
--- a/releases/publish.go
+++ b/releases/publish.go
@@ -102,14 +102,14 @@ func publishPackage(pkgType string, name string) {
 		must.RunV("git", "tag", info.Permalink, info.Version+"^{}", "-f")
 		must.RunV("git", "push", "-f", remote, info.Permalink)
 
-		AddFilesToRelease(repo, info, info.Permalink, versionDir)
+		AddFilesToRelease(repo, info.Permalink, versionDir)
 	} else {
 		fmt.Println("Skipping publish package for permalink", info.Permalink)
 	}
 
 	// Create GitHub release for the exact version (v1.2.3) and attach assets
 	if info.IsTaggedRelease {
-		AddFilesToRelease(repo, info, info.Version, versionDir)
+		AddFilesToRelease(repo, info.Version, versionDir)
 	}
 }
 
@@ -181,7 +181,7 @@ func GeneratePluginFeed() error {
 
 // AddFilesToRelease uploads the files in the specified directory to a GitHub release.
 // If the release does not exist already, it will be created with empty release notes.
-func AddFilesToRelease(repo string, info GitMetadata, tag string, dir string) {
+func AddFilesToRelease(repo string, tag string, dir string) {
 	files, err := getReleaseAssets(dir)
 	mgx.Must(err)
 

--- a/tools/install.go
+++ b/tools/install.go
@@ -17,6 +17,9 @@ import (
 var (
 	must = shx.CommandBuilder{StopOnError: true}
 
+	// DefaultGitHubClientVersion is the version of gh that is installed when it's not present
+	DefaultGitHubClientVersion = "2.27.0"
+
 	// DefaultKindVersion is the default version of KinD that is installed when it's not present
 	DefaultKindVersion = "v0.12.0"
 
@@ -66,7 +69,7 @@ func EnsureGitHubClient() {
 		DownloadOptions: downloads.DownloadOptions{
 			UrlTemplate: "https://github.com/cli/cli/releases/download/v{{.VERSION}}/gh_{{.VERSION}}_{{.GOOS}}_{{.GOARCH}}{{.EXT}}",
 			Name:        "gh",
-			Version:     "1.8.1",
+			Version:     DefaultGitHubClientVersion,
 			OsReplacement: map[string]string{
 				"darwin": "macOS",
 			},

--- a/tools/install_test.go
+++ b/tools/install_test.go
@@ -49,7 +49,7 @@ func TestEnsureStaticCheck(t *testing.T) {
 	oldPath := os.Getenv("PATH")
 	defer os.Setenv("PATH", oldPath)
 	os.Setenv("PATH", tmp)
-	
+
 	tools.EnsureStaticCheck()
 	xplat.PrependPath(gopath.GetGopathBin())
 
@@ -58,4 +58,27 @@ func TestEnsureStaticCheck(t *testing.T) {
 	found, err := pkg.IsCommandAvailable("staticcheck", "--version", tools.DefaultStaticCheckVersion)
 	require.NoError(t, err, "IsCommandAvailable failed")
 	assert.True(t, found, "staticcheck was not available from its location in GOPATH/bin. PATH=%s", os.Getenv("PATH"))
+}
+
+func TestEnsureGitHubClient(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "magefiles")
+	require.NoError(t, err, "Error creating temp directory")
+	defer os.RemoveAll(tmp)
+
+	oldGoPath := os.Getenv("GOPATH")
+	defer os.Setenv("GOPATH", oldGoPath)
+	os.Setenv("GOPATH", tmp)
+
+	oldPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oldPath)
+	os.Setenv("PATH", tmp)
+
+	tools.EnsureGitHubClient()
+	xplat.PrependPath(gopath.GetGopathBin())
+
+	require.FileExists(t, filepath.Join(tmp, "bin", "gh"+xplat.FileExt()))
+
+	found, err := pkg.IsCommandAvailable("gh", "--version", tools.DefaultGitHubClientVersion)
+	require.NoError(t, err, "IsCommandAvailable failed")
+	assert.True(t, found, "gh was not available from its location in GOPATH/bin. PATH=%s", os.Getenv("PATH"))
 }


### PR DESCRIPTION
When we create the github release, upload the assets at the same time, so that github is responsible for apply the latest flag to the release and only applies latest when all assets are uploaded. Right now there is a delay between when the release is created and when the assets are available, which causes the "install latest" script to fail for a short period of time after a release is created. I looked into managing the latest flag ourselves, so that we can flip it after we upload the assets but gh is doing a lot of logic around if it's the most recent and highest semver tag, and I'd like to not replicate that logic.

In the past I have seen create release fail when uploading assets during release creation, which is why it was originally split into two steps. Now that the code is checking for the existence of the release and re-uploading assets, that shouldn't be a problem. If a release fails while uploading, it won't have latest applied yet to it and we can kick the build to retry the upload to the release. I am also ensuring that the release isn't still marked as a draft when we retry uploading the assets. If asset upload fails during release creation, the release is left in draft and the draft flag needs to be removed once we finish uploading the assets during retry.

I have also turned on automatic release note creation so that we don't need to do that manually after the release is finished.

This is the groundwork for https://github.com/getporter/porter/issues/2723. It won't go live until we update our go.mod in each repository that uses this package though.