### PR TITLE
Update staticcheck to be used with gov1.20

### DIFF
--- a/tools/install.go
+++ b/tools/install.go
@@ -24,7 +24,7 @@ var (
 	DefaultKindVersion = "v0.12.0"
 
 	// DefaultStaticCheckVersion is the default version of StaticCheck that is installed when it's not present
-	DefaultStaticCheckVersion = "2022.1.2"
+	DefaultStaticCheckVersion = "2023.1.3"
 )
 
 // Fail if the go version doesn't match the specified constraint


### PR DESCRIPTION
Doing `go install honnef.co/go/tools/cmd/staticcheck@latest` gives you  staticcheck 2023.1.3 (v0.4.3).  This works with gov1.20 

- [x] Update version for staticcheck
