### PR TITLE
Remove errors from staticcheck and go vet with gov1.20

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,11 +19,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
       - name: Configure Agent
         run: go run mage.go ConfigureAgent
+      - name: Vet
+        run: mage Vet
+      - name: Lint
+        run: mage Lint
       - name: Build
         run: mage Build
       - name: Test

--- a/ci/azure.go
+++ b/ci/azure.go
@@ -8,7 +8,7 @@ import (
 	"get.porter.sh/magefiles/tools"
 	"github.com/carolynvs/magex/pkg/gopath"
 
-	. "github.com/carolynvs/magex/ci"
+	"github.com/carolynvs/magex/ci"
 )
 
 // ConfigureAgent sets up a CI worker agent with mage and ensures
@@ -26,7 +26,7 @@ func ConfigureAgent() error {
 		return fmt.Errorf("could not mkdir -p %s: %w", gobin, err)
 	}
 
-	p, _ := DetectBuildProvider()
+	p, _ := ci.DetectBuildProvider()
 	log.Printf("Adding %s to the PATH\n", gobin)
 	return p.PrependPath(gobin)
 }

--- a/docker/images.go
+++ b/docker/images.go
@@ -23,5 +23,5 @@ func ExtractRepoDigest(inspectOutput string) (string, error) {
 		}
 	}
 
-	return "", errors.New("No repository digests are associated with the image. Did you push it?")
+	return "", errors.New("no repository digests are associated with the image. Did you push it?")
 }

--- a/git/dco.go
+++ b/git/dco.go
@@ -19,7 +19,7 @@ var prepareCommitMsg string
 func SetupDCO() error {
 	gotShell := xplat.DetectShell()
 	if gotShell == "powershell" || gotShell == "cmd" {
-		return fmt.Errorf("SetupDCO must be run from a shell that supports bash but %s was detected\n", gotShell)
+		return fmt.Errorf("setupDCO must be run from a shell that supports bash but %s was detected", gotShell)
 	}
 
 	pwd, err := os.Getwd()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module get.porter.sh/magefiles
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1

--- a/magefile.go
+++ b/magefile.go
@@ -6,6 +6,7 @@ package main
 import (
 	"get.porter.sh/magefiles/ci"
 	"get.porter.sh/magefiles/porter"
+	"get.porter.sh/magefiles/tools"
 	"github.com/carolynvs/magex/mgx"
 	"github.com/carolynvs/magex/shx"
 	"github.com/magefile/mage/mg"
@@ -19,6 +20,16 @@ func ConfigureAgent() {
 
 func Build() {
 	must.RunV("go", "build", "./...")
+}
+
+func Vet() {
+	must.RunV("go", "vet", "./...")
+}
+
+// Run staticcheck on the project
+func Lint() {
+	mg.Deps(tools.EnsureStaticCheck)
+	must.RunV("staticcheck", "./...")
 }
 
 func Test() {

--- a/porter/config_test.go
+++ b/porter/config_test.go
@@ -1,7 +1,6 @@
 package porter
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 
 func TestGetPorterHome(t *testing.T) {
 	t.Run("PORTER_HOME set", func(t *testing.T) {
-		tmpPorterHome, err := ioutil.TempDir("", "magefiles")
+		tmpPorterHome, err := os.MkdirTemp("", "magefiles")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmpPorterHome)
 
@@ -25,7 +24,7 @@ func TestGetPorterHome(t *testing.T) {
 	})
 
 	t.Run("Default to HOME/.porter", func(t *testing.T) {
-		tmpUserHome, err := ioutil.TempDir("", "magefiles")
+		tmpUserHome, err := os.MkdirTemp("", "magefiles")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmpUserHome)
 		tmpPorterHome := filepath.Join(tmpUserHome, ".porter")

--- a/porter/porter_test.go
+++ b/porter/porter_test.go
@@ -1,7 +1,6 @@
 package porter
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestEnsurePorter(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "magefiles")
+	tmp, err := os.MkdirTemp("", "magefiles")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmp)
 

--- a/releases/publish.go
+++ b/releases/publish.go
@@ -137,7 +137,7 @@ func publishPackageFeed(pkgType string, name string) {
 	}
 	remote := os.Getenv(PackagesRemote)
 	if remote == "" {
-		remote = fmt.Sprintf("https://github.com/getporter/packages.git")
+		remote = "https://github.com/getporter/packages.git"
 	}
 	must.RunV("git", "clone", "--depth=1", remote, packagesRepo)
 	configureGitBotIn(packagesRepo)

--- a/releases/publish_test.go
+++ b/releases/publish_test.go
@@ -3,7 +3,6 @@ package releases
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,7 +15,7 @@ import (
 )
 
 func TestGetReleaseAssets(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "magefiles")
+	tmp, err := os.MkdirTemp("", "magefiles")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmp)
 
@@ -36,7 +35,7 @@ func TestGetReleaseAssets(t *testing.T) {
 	assert.Equal(t, wantFiles, gotFiles)
 
 	// Read the existing checksum file with stale contents, and ensure it was updated
-	gotChecksum, err := ioutil.ReadFile(filepath.Join(tmp, "mymixin-darwin-amd64.sha256sum"))
+	gotChecksum, err := os.ReadFile(filepath.Join(tmp, "mymixin-darwin-amd64.sha256sum"))
 	require.NoError(t, err)
 	wantCheckSum := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  mymixin-darwin-amd64"
 	assert.Equal(t, wantCheckSum, string(gotChecksum))
@@ -83,7 +82,7 @@ func TestAppendDataPath(t *testing.T) {
 }
 
 func TestGenerateMixinFeed(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "magefiles")
+	tmp, err := os.MkdirTemp("", "magefiles")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmp)
 
@@ -113,7 +112,7 @@ func TestGenerateMixinFeed(t *testing.T) {
 }
 
 func TestGeneratePluginFeed_PorterNotInstalled(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "magefiles")
+	tmp, err := os.MkdirTemp("", "magefiles")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmp)
 

--- a/tests/kind.go
+++ b/tests/kind.go
@@ -5,7 +5,7 @@ import (
 	_ "embed"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -69,17 +69,13 @@ func useCluster() bool {
 		}
 		os.Setenv("KUBECONFIG", currentKubeConfig)
 
-		if err := ioutil.WriteFile(Kubeconfig, []byte(contents), 0660); err != nil {
+		if err := os.WriteFile(Kubeconfig, []byte(contents), 0660); err != nil {
 			mgx.Must(fmt.Errorf("error writing %s: %w", Kubeconfig, err))
 		}
 		return true
 	}
 
 	return false
-}
-
-func setClusterNamespace(name string) {
-	must.RunE("kubectl", "config", "set-context", "--current", "--namespace", name)
 }
 
 // Create a KIND cluster named porter.
@@ -119,7 +115,7 @@ func CreateTestCluster() {
 	if err = kindCfgTmpl.Execute(&kindCfgContents, kindCfgData); err != nil {
 		mgx.Must(fmt.Errorf("could not render the kind.config template: %w", err))
 	}
-	if err = ioutil.WriteFile("kind.config.yaml", kindCfgContents.Bytes(), 0660); err != nil {
+	if err = os.WriteFile("kind.config.yaml", kindCfgContents.Bytes(), 0660); err != nil {
 		mgx.Must(fmt.Errorf("could not write kind config file: %w", err))
 	}
 	defer os.Remove("kind.config.yaml")
@@ -162,7 +158,7 @@ func EnsureKubectl() {
 	}
 	defer versionResp.Body.Close()
 
-	kubectlVersion, err := ioutil.ReadAll(versionResp.Body)
+	kubectlVersion, err := io.ReadAll(versionResp.Body)
 	if err != nil {
 		mgx.Must(fmt.Errorf("error reading response from %s: %w", versionURL, err))
 	}

--- a/tools/install.go
+++ b/tools/install.go
@@ -11,12 +11,9 @@ import (
 	"github.com/carolynvs/magex/pkg"
 	"github.com/carolynvs/magex/pkg/archive"
 	"github.com/carolynvs/magex/pkg/downloads"
-	"github.com/carolynvs/magex/shx"
 )
 
 var (
-	must = shx.CommandBuilder{StopOnError: true}
-
 	// DefaultGitHubClientVersion is the version of gh that is installed when it's not present
 	DefaultGitHubClientVersion = "2.27.0"
 

--- a/tools/install_test.go
+++ b/tools/install_test.go
@@ -1,7 +1,6 @@
 package tools_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestEnsureKind(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "magefiles")
+	tmp, err := os.MkdirTemp("", "magefiles")
 	require.NoError(t, err, "Error creating temp directory")
 	defer os.RemoveAll(tmp)
 
@@ -38,7 +37,7 @@ func TestEnsureKind(t *testing.T) {
 }
 
 func TestEnsureStaticCheck(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "magefiles")
+	tmp, err := os.MkdirTemp("", "magefiles")
 	require.NoError(t, err, "Error creating temp directory")
 	defer os.RemoveAll(tmp)
 


### PR DESCRIPTION
With the addition of the new staticcheck version added in the last release, the check(s) performed on this repository produced a number of errors.  Within those errors it was noted that there were several mage targets that could be utilized to ensure the integrity of this repository.  

 - [x] Add vet
 - [x] Add lint/staticcheck
 - [x] Fix errors with staticcheck and go vet for go1.20
- [x] Updated github workflow
