### PR TITLE
Update kind to v0.20.0

### DIFF
--- a/tools/install.go
+++ b/tools/install.go
@@ -18,7 +18,7 @@ var (
 	DefaultGitHubClientVersion = "2.27.0"
 
 	// DefaultKindVersion is the default version of KinD that is installed when it's not present
-	DefaultKindVersion = "v0.12.0"
+	DefaultKindVersion = "v0.20.0"
 
 	// DefaultStaticCheckVersion is the default version of StaticCheck that is installed when it's not present
 	DefaultStaticCheckVersion = "2023.1.3"


### PR DESCRIPTION
Currently kind is set to version v0.12.0 and will overwrite the current kind to this when using the magefiles in the repository.  This version makes clusters at 1.23 instead of 1.27.x 

- [x] Updates kind to v0.20.0

Resolves #28 
