### PR TITLE
fix: Updtaed the default porter version to current latest due to brea…

### DIFF
--- a/porter/porter.go
+++ b/porter/porter.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	// DefaultPorterVersion is the default version of Porter that is installed when it's not present
-	DefaultPorterVersion = "v1.0.1"
+	DefaultPorterVersion = "v1.0.16"
 )
 
 // Install the default version of porter, if porter isn't already installed


### PR DESCRIPTION
…king docker onprevious version

* V1.0.1 invocation image had a broken debian reference that was fixed. Updated to latest porter (v1.0.16) to get current working porter version