### PR TITLE
Add command to install golangci-lint and fixed local linting errors

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -26,10 +26,10 @@ func Vet() {
 	must.RunV("go", "vet", "./...")
 }
 
-// Run staticcheck on the project
+// Run golangci-lint on the project
 func Lint() {
-	mg.Deps(tools.EnsureStaticCheck)
-	must.RunV("staticcheck", "./...")
+	mg.Deps(tools.EnsureGolangCILint)
+	must.RunV("golangci-lint", "run", "./...")
 }
 
 func Test() {

--- a/mixins/magefile.go
+++ b/mixins/magefile.go
@@ -34,7 +34,7 @@ func (m Magefile) ConfigureAgent() {
 
 // Build the mixin
 func (m Magefile) Build() {
-	must.RunV("go", "mod", "tidy")
+	mgx.Must(must.RunV("go", "mod", "tidy"))
 	mgx.Must(releases.BuildAll(m.Pkg, m.MixinName, m.BinDir))
 }
 
@@ -50,7 +50,7 @@ func (m Magefile) TestUnit() {
 	if mg.Verbose() {
 		v = "-v"
 	}
-	must.Command("go", "test", v, "./pkg/...").CollapseArgs().RunV()
+	mgx.Must(must.Command("go", "test", v, "./pkg/...").CollapseArgs().RunV())
 }
 
 // Test runs a full suite of tests
@@ -59,7 +59,7 @@ func (m Magefile) Test() {
 
 	// Check that we can call `mixin version`
 	m.Build()
-	must.RunV(filepath.Join(m.BinDir, m.MixinName+xplat.FileExt()), "version")
+	mgx.Must(must.RunV(filepath.Join(m.BinDir, m.MixinName+xplat.FileExt()), "version"))
 }
 
 // Publish the mixin and its mixin feed
@@ -101,7 +101,7 @@ func (m Magefile) Install() {
 	porterHome := porter.GetPorterHome()
 	fmt.Printf("Installing the %s mixin into %s\n", m.MixinName, porterHome)
 
-	os.MkdirAll(filepath.Join(porterHome, "mixins", m.MixinName, "runtimes"), 0770)
+	mgx.Must(os.MkdirAll(filepath.Join(porterHome, "mixins", m.MixinName, "runtimes"), 0770))
 	mgx.Must(shx.Copy(filepath.Join(m.BinDir, m.MixinName+xplat.FileExt()), filepath.Join(porterHome, "mixins", m.MixinName)))
 	mgx.Must(shx.Copy(filepath.Join(m.BinDir, "runtimes", m.MixinName+"-runtime"+xplat.FileExt()), filepath.Join(porterHome, "mixins", m.MixinName, "runtimes")))
 }

--- a/porter/config.go
+++ b/porter/config.go
@@ -1,6 +1,7 @@
 package porter
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -30,7 +31,10 @@ func UseBinForPorterHome() {
 	// use bin as PORTER_HOME
 	wd, _ := os.Getwd()
 	home := filepath.Join(wd, "bin")
-	os.Mkdir(home, 0770)
+	err := os.Mkdir(home, 0770)
+	if err != nil && !os.IsExist(err) {
+		panic(fmt.Sprintf("Unable to make directory %s for PORTER_HOME", home))
+	}
 	UsePorterHome(home)
 }
 

--- a/porter/porter.go
+++ b/porter/porter.go
@@ -31,7 +31,7 @@ func EnsurePorter() {
 func EnsurePorterAt(version string) {
 	home := GetPorterHome()
 	runtimesDir := filepath.Join(home, "runtimes")
-	os.MkdirAll(runtimesDir, 0770)
+	mgx.Must(os.MkdirAll(runtimesDir, 0770))
 
 	var forceDownloadRuntime bool
 

--- a/releases/build.go
+++ b/releases/build.go
@@ -26,7 +26,7 @@ func getLDFLAGS(pkg string) string {
 func build(pkgName, cmd, outPath, goos, goarch string) error {
 	ldflags := getLDFLAGS(pkgName)
 
-	os.MkdirAll(filepath.Dir(outPath), 0770)
+	mgx.Must(os.MkdirAll(filepath.Dir(outPath), 0770))
 	outPath += fileExt(goos)
 	srcPath := "./cmd/" + cmd
 
@@ -88,5 +88,5 @@ func XBuildAll(pkg string, name string, binDir string) {
 
 	// Copy most recent build into bin/dev so that subsequent build steps can easily find it, not used for publishing
 	os.RemoveAll(filepath.Join(binDir, "dev"))
-	shx.Copy(filepath.Join(binDir, info.Version), filepath.Join(binDir, "dev"), shx.CopyRecursive)
+	mgx.Must(shx.Copy(filepath.Join(binDir, info.Version), filepath.Join(binDir, "dev"), shx.CopyRecursive))
 }

--- a/releases/publish_test.go
+++ b/releases/publish_test.go
@@ -103,7 +103,9 @@ func TestGenerateMixinFeed(t *testing.T) {
 	origDir, err := os.Getwd()
 	require.NoError(t, err)
 	require.NoError(t, os.Chdir(tmp))
-	defer os.Chdir(origDir)
+	defer func() {
+		require.NoError(t, os.Chdir(origDir))
+	}()
 
 	err = GenerateMixinFeed()
 	require.NoError(t, err)
@@ -131,7 +133,9 @@ func TestGeneratePluginFeed_PorterNotInstalled(t *testing.T) {
 	origDir, err := os.Getwd()
 	require.NoError(t, err)
 	require.NoError(t, os.Chdir(tmp))
-	defer os.Chdir(origDir)
+	defer func() {
+		require.NoError(t, os.Chdir(origDir))
+	}()
 
 	err = GeneratePluginFeed()
 	require.Errorf(t, err, "farts", "GeneratePluginFeed should fail when porter is not in the bin")

--- a/tests/kind.go
+++ b/tests/kind.go
@@ -125,21 +125,21 @@ func CreateTestCluster() {
 	}
 	defer os.Remove("kind.config.yaml")
 
-	must.Command("kind", "create", "cluster", "--name", getKindClusterName(), "--config", "kind.config.yaml").
-		Env("KIND_EXPERIMENTAL_DOCKER_NETWORK=" + docker.DefaultNetworkName).Run()
+	mgx.Must(must.Command("kind", "create", "cluster", "--name", getKindClusterName(), "--config", "kind.config.yaml").
+		Env("KIND_EXPERIMENTAL_DOCKER_NETWORK=" + docker.DefaultNetworkName).Run())
 
 	// Document the local registry
-	kubectl("apply", "-f", "-").
+	mgx.Must(kubectl("apply", "-f", "-").
 		Stdin(strings.NewReader(templateLocalRegistry)).
-		Run()
-	kubectl("config", "use-context", "kind-porter").Run()
+		Run())
+	mgx.Must(kubectl("config", "use-context", "kind-porter").Run())
 }
 
 // Delete the KIND cluster named porter.
 func DeleteTestCluster() {
 	mg.Deps(tools.EnsureKind)
 
-	must.RunE("kind", "delete", "cluster", "--name", getKindClusterName())
+	mgx.Must(must.RunE("kind", "delete", "cluster", "--name", getKindClusterName()))
 }
 
 func kubectl(args ...string) shx.PreparedCommand {

--- a/tools/install.go
+++ b/tools/install.go
@@ -22,6 +22,9 @@ var (
 
 	// DefaultStaticCheckVersion is the default version of StaticCheck that is installed when it's not present
 	DefaultStaticCheckVersion = "2023.1.6"
+
+	// DefaultGolangCILintVersion is the default version of golangci-lint that is installed when it's not present
+	DefaultGolangCILintVersion = "1.57.2"
 )
 
 // Fail if the go version doesn't match the specified constraint
@@ -127,6 +130,34 @@ func EnsureStaticCheckAt(version string) {
 			"windows": ".tar.gz",
 		},
 		TargetFileTemplate: "staticcheck/staticcheck{{.EXT}}",
+	}
+	err := archive.DownloadToGopathBin(opts)
+	mgx.Must(err)
+}
+
+// Install golangci-lint
+func EnsureGolangCILint() {
+	EnsureGolangCILintAt(DefaultGolangCILintVersion)
+}
+
+// Install golangci-lint at the specified version
+func EnsureGolangCILintAt(version string) {
+	if ok, _ := pkg.IsCommandAvailable("golangci-lint", "--version", version); ok {
+		return
+	}
+
+	opts := archive.DownloadArchiveOptions{
+		DownloadOptions: downloads.DownloadOptions{
+			UrlTemplate: "https://github.com/golangci/golangci-lint/releases/download/v{{.VERSION}}/golangci-lint-{{.VERSION}}-{{.GOOS}}-{{.GOARCH}}.tar.gz",
+			Name:        "golangci-lint",
+			Version:     version,
+		},
+		ArchiveExtensions: map[string]string{
+			"linux":   ".tar.gz",
+			"darwin":  ".tar.gz",
+			"windows": ".tar.gz",
+		},
+		TargetFileTemplate: "golangci-lint-{{.VERSION}}-{{.GOOS}}-{{.GOARCH}}/golangci-lint{{.EXT}}",
 	}
 	err := archive.DownloadToGopathBin(opts)
 	mgx.Must(err)

--- a/tools/install_test.go
+++ b/tools/install_test.go
@@ -59,6 +59,29 @@ func TestEnsureStaticCheck(t *testing.T) {
 	assert.True(t, found, "staticcheck was not available from its location in GOPATH/bin. PATH=%s", os.Getenv("PATH"))
 }
 
+func TestEnsureGolangCILint(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "magefiles")
+	require.NoError(t, err, "Error creating temp directory")
+	defer os.RemoveAll(tmp)
+
+	oldGoPath := os.Getenv("GOPATH")
+	defer os.Setenv("GOPATH", oldGoPath)
+	os.Setenv("GOPATH", tmp)
+
+	oldPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oldPath)
+	os.Setenv("PATH", tmp)
+
+	tools.EnsureGolangCILint()
+	xplat.PrependPath(gopath.GetGopathBin())
+
+	require.FileExists(t, filepath.Join(tmp, "bin", "golangci-lint"+xplat.FileExt()))
+
+	found, err := pkg.IsCommandAvailable("golangci-lint", "--version", tools.DefaultGolangCILintVersion)
+	require.NoError(t, err, "IsCommandAvailable failed")
+	assert.True(t, found, "golangci-lint was not available from its location in GOPATH/bin. PATH=%s", os.Getenv("PATH"))
+}
+
 func TestEnsureGitHubClient(t *testing.T) {
 	tmp, err := os.MkdirTemp("", "magefiles")
 	require.NoError(t, err, "Error creating temp directory")


### PR DESCRIPTION
Added a command to the magefiles to allow for the install of golangci-lint, updated the build to use it for linting, and then fixed the local linting errors!

Prerequisite for getporter/porter#3048