### PR TITLE
Change from Azure DevOps environment variables to Github environment variables

### DIFF
--- a/releases/git.go
+++ b/releases/git.go
@@ -97,14 +97,14 @@ func getBranchName() string {
 func pickBranchName(refs []string) string {
 	var branch string
 
-	if b, ok := os.LookupEnv("SYSTEM_PULLREQUEST_SOURCEBRANCH"); ok {
+	if b, ok := os.LookupEnv("GITHUB_HEAD_REF"); ok {
 		// pull request
 		branch = b
-	} else if b, ok := os.LookupEnv("BUILD_SOURCEBRANCH"); ok && !strings.HasPrefix(b, "refs/tags/") {
+	} else if b, ok := os.LookupEnv("GITHUB_REF"); ok && !strings.HasPrefix(b, "refs/tags/") {
 		// branch build
-		// BUILD_SOURCEBRANCHNAME has the short name, e.g. main. BUILD_SOURCEBRANCH has the full name, e.g. refs/heads/main
+		// GITHUB_REF_NAME has the short name, e.g. main. GITHUB_REF has the full name, e.g. refs/heads/main
 		// They are populated for both tags and branches
-		branch = os.Getenv("BUILD_SOURCEBRANCHNAME")
+		branch = os.Getenv("GITHUB_REF_NAME")
 	} else {
 		// tag build
 		// Detect if this was a tag on main or a release
@@ -138,7 +138,7 @@ func pickBranchName(refs []string) string {
 
 func getPermalink() (string, bool) {
 	// Use dev for pull requests
-	if _, pr := os.LookupEnv("SYSTEM_PULLREQUEST_SOURCEBRANCH"); pr {
+	if _, pr := os.LookupEnv("GITHUB_HEAD_REF"); pr {
 		return "dev", false
 	}
 

--- a/releases/git_test.go
+++ b/releases/git_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestPickBranchName(t *testing.T) {
 	// These aren't set locally but are set on a CI run
-	os.Unsetenv("SYSTEM_PULLREQUEST_SOURCEBRANCH")
-	os.Unsetenv("BUILD_SOURCEBRANCHNAME")
-	os.Unsetenv("BUILD_SOURCEBRANCH")
+	os.Unsetenv("GITHUB_HEAD_REF")
+	os.Unsetenv("GITHUB_REF_NAME")
+	os.Unsetenv("GITHUB_REF")
 
 	t.Run("origin/main", func(t *testing.T) {
 		refs := []string{
@@ -36,8 +36,8 @@ func TestPickBranchName(t *testing.T) {
 	})
 
 	t.Run("pull request", func(t *testing.T) {
-		os.Setenv("SYSTEM_PULLREQUEST_SOURCEBRANCH", "patch-1")
-		defer os.Unsetenv("SYSTEM_PULLREQUEST_SOURCEBRANCH")
+		os.Setenv("GITHUB_HEAD_REF", "patch-1")
+		defer os.Unsetenv("GITHUB_HEAD_REF")
 
 		refs := []string{
 			"refs/remotes/origin/foo",
@@ -48,10 +48,10 @@ func TestPickBranchName(t *testing.T) {
 	})
 
 	t.Run("branch build", func(t *testing.T) {
-		os.Setenv("BUILD_SOURCEBRANCHNAME", "foo")
-		os.Setenv("BUILD_SOURCEBRANCH", "refs/heads/foo")
-		defer os.Unsetenv("BUILD_SOURCEBRANCHNAME")
-		defer os.Unsetenv("BUILD_SOURCEBRANCH")
+		os.Setenv("GITHUB_REF_NAME", "foo")
+		os.Setenv("GITHUB_REF", "refs/heads/foo")
+		defer os.Unsetenv("GITHUB_REF_NAME")
+		defer os.Unsetenv("GITHUB_REF")
 
 		refs := []string{
 			"refs/remotes/origin/foo",
@@ -62,10 +62,10 @@ func TestPickBranchName(t *testing.T) {
 	})
 
 	t.Run("tagged release on v1", func(t *testing.T) {
-		os.Setenv("BUILD_SOURCEBRANCHNAME", "v1.0.0-alpha.1")
-		os.Setenv("BUILD_SOURCEBRANCH", "refs/tags/v1.0.0-alpha.1")
-		defer os.Unsetenv("BUILD_SOURCEBRANCHNAME")
-		defer os.Unsetenv("BUILD_SOURCEBRANCH")
+		os.Setenv("GITHUB_REF_NAME", "v1.0.0-alpha.1")
+		os.Setenv("GITHUB_REF", "refs/tags/v1.0.0-alpha.1")
+		defer os.Unsetenv("GITHUB_REF_NAME")
+		defer os.Unsetenv("GITHUB_REF")
 
 		refs := []string{
 			"refs/heads/release/v1",
@@ -77,10 +77,10 @@ func TestPickBranchName(t *testing.T) {
 	})
 
 	t.Run("tagged release on main", func(t *testing.T) {
-		os.Setenv("BUILD_SOURCEBRANCHNAME", "v0.38.3")
-		os.Setenv("BUILD_SOURCEBRANCH", "refs/tags/v0.38.3")
-		defer os.Unsetenv("BUILD_SOURCEBRANCHNAME")
-		defer os.Unsetenv("BUILD_SOURCEBRANCH")
+		os.Setenv("GITHUB_REF_NAME", "v0.38.3")
+		os.Setenv("GITHUB_REF", "refs/tags/v0.38.3")
+		defer os.Unsetenv("GITHUB_REF_NAME")
+		defer os.Unsetenv("GITHUB_REF")
 
 		refs := []string{
 			"refs/heads/release/v1",


### PR DESCRIPTION
Change from Azure DevOps environment variables to Github environment variables, this ensure that the detection of permalink and branch name is correct when running in Github Actions