### PR TITLE
Calculate version correctly when multiple tags are present

### DIFF
--- a/releases/git.go
+++ b/releases/git.go
@@ -81,7 +81,7 @@ func getCommit() string {
 
 // Get a description of the commit, e.g. v0.30.1 (latest) or v0.30.1-32-gfe72ff73 (canary)
 func getVersion() string {
-	version, _ := shx.OutputS("git", "describe", "--tags")
+	version, _ := shx.OutputS("git", "describe", "--tags", "--match=v*")
 	if version != "" {
 		return version
 	}


### PR DESCRIPTION
When multiple tags are present on the same commit, the version was calculated incorrectly. E.g., when `latest`, `canary` and `v1.1.0` tags are present on the same commit, the command seems to sort alphabetically causing the version to always be set to `canary`. This behaviour breaks makes it impossible to release a finalized version, e.g., `v1.1.0`.

Using matching results in the version being calculated from the latest released version. The version will look like this `v1.1.0-2-gf3862833` instead of `canary` when running a canary build.