### PR TITLE
chore(deps): bump golangci-lint from 1.57.2 to 1.62.0

### DIFF
--- a/tools/install.go
+++ b/tools/install.go
@@ -24,7 +24,7 @@ var (
 	DefaultStaticCheckVersion = "2023.1.6"
 
 	// DefaultGolangCILintVersion is the default version of golangci-lint that is installed when it's not present
-	DefaultGolangCILintVersion = "1.57.2"
+	DefaultGolangCILintVersion = "1.62.0"
 )
 
 // Fail if the go version doesn't match the specified constraint


### PR DESCRIPTION
* Update golangci-lint version to support Go 1.23
* Only golangci-lint versions above 1.60 are compatible with Go 1.23

Part of the fix for https://github.com/getporter/porter/issues/3254